### PR TITLE
externpro 26.01.1-19-ge3220ab

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,15 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.19
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.1
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with: {}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.19
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.1
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.19
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.1
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.19
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.1
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.19
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.1
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.31)
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 4.3)
 project(bzip2 VERSION 1.0.8 LANGUAGES C)
 set(lib_name bz2)
+set(exe_name bzip2exe)
 ########################################
 add_definitions(-D_FILE_OFFEST_BITS=64)
 ########################################
@@ -22,9 +22,12 @@ target_include_directories(${lib_name} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTAL
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   )
 ########################################
-add_executable(bzip2 bzip2.c)
-target_link_libraries(bzip2 ${lib_name})
-set_target_properties(bzip2 PROPERTIES DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
+add_executable(${exe_name} bzip2.c)
+set_target_properties(${exe_name} PROPERTIES
+  OUTPUT_NAME "bzip2"
+  DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}"
+  )
+target_link_libraries(${exe_name} PRIVATE ${lib_name})
 ########################################
 add_executable(bzip2recover bzip2recover.c)
 set_target_properties(bzip2recover PROPERTIES DEBUG_POSTFIX "${CMAKE_DEBUG_POSTFIX}")
@@ -32,7 +35,7 @@ set_target_properties(bzip2recover PROPERTIES DEBUG_POSTFIX "${CMAKE_DEBUG_POSTF
 include(CTest)
 add_test(NAME bzip2_check
   COMMAND ${CMAKE_COMMAND}
-    -DCMD=$<TARGET_FILE:bzip2>
+    -DCMD=$<TARGET_FILE:${exe_name}>
     -DSRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}
     -DBIN_DIR=${CMAKE_CURRENT_BINARY_DIR}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/run_bzip2_test.cmake
@@ -45,28 +48,29 @@ install(TARGETS ${lib_name} EXPORT ${targetsFile}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
-install(TARGETS bzip2 bzip2recover EXPORT ${targetsFile}
+install(TARGETS ${exe_name} bzip2recover EXPORT ${targetsFile}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   CONFIGURATIONS Release
   )
-install(PROGRAMS $<TARGET_FILE:bzip2> DESTINATION ${CMAKE_INSTALL_BINDIR} CONFIGURATIONS Release RENAME bunzip2${CMAKE_EXECUTABLE_SUFFIX})
-install(PROGRAMS $<TARGET_FILE:bzip2> DESTINATION ${CMAKE_INSTALL_BINDIR} CONFIGURATIONS Release RENAME bzcat${CMAKE_EXECUTABLE_SUFFIX})
+install(PROGRAMS $<TARGET_FILE:${exe_name}> DESTINATION ${CMAKE_INSTALL_BINDIR} CONFIGURATIONS Release RENAME bunzip2${CMAKE_EXECUTABLE_SUFFIX})
+install(PROGRAMS $<TARGET_FILE:${exe_name}> DESTINATION ${CMAKE_INSTALL_BINDIR} CONFIGURATIONS Release RENAME bzcat${CMAKE_EXECUTABLE_SUFFIX})
 install(FILES bzlib.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
-if(DEFINED XP_NAMESPACE)
+if(COMMAND xpExternPackage)
   string(JOIN "\n" ALIASES
     "if(NOT TARGET BZip2::BZip2)"
-    "  add_library(BZip2::BZip2 ALIAS ${XP_NAMESPACE}::${lib_name})"
+    "  add_library(BZip2::BZip2 ALIAS ${CMAKE_PROJECT_NAME}::${lib_name})"
     "endif()"
     ""
     )
-  xpExternPackage(NAMESPACE ${XP_NAMESPACE}
-    TARGETS_FILE ${targetsFile} LIBRARIES ${lib_name} EXE bzip2
+  xpExternPackage(TARGETS_FILE ${targetsFile}
+    FIND_XPRO_CMAKE PKG_CMAKE_USEXT CREATE_ALIASES
+    LIBRARIES ${lib_name} EXE ${exe_name} DEFAULT_TARGETS ${lib_name}
     BASE ${CMAKE_PROJECT_NAME}-${CMAKE_PROJECT_VERSION} XPDIFF "intro"
     WEB "https://sourceware.org/bzip2/" UPSTREAM "github.com/opencor/bzip2"
     DESC "lossless block-sorting data compression library"
     LICENSE "[bzip2-1.0.6](https://spdx.org/licenses/bzip2-1.0.6.html 'BSD-like, modified zlib license')"
     )
-  install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} NAMESPACE ${XP_NAMESPACE}::)
+  install(EXPORT ${targetsFile} DESTINATION ${CMAKE_INSTALL_CMAKEDIR} NAMESPACE ${CMAKE_PROJECT_NAME}::)
 endif()

--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -6,7 +6,7 @@
       "hidden": true,
       "binaryDir": "${sourceDir}/_bld-${presetName}",
       "cacheVariables": {
-        "XP_NAMESPACE": "xpro"
+        "CMAKE_EXPERIMENTAL_GENERATE_SBOM": "ca494ed3-b261-4205-a01f-603c95e4cae0"
       }
     }
   ],


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-19-ge3220ab`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-19-ge3220ab`
- Previous HEAD: `c83cc8766aa3d0afb1266afa33c6d1c51dd66716`
- New HEAD: `e3220ab439d4475eb9bb6b9a9c84919ba63d095e`
- If you add the \"release:tag\" label, the tag will be \`xpv1.0.8.5\`
- Updated caller workflows to match templates

### Workflow Update Report

- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
